### PR TITLE
Adding FLATWARE_USE_OLD_SHEETS environment variable. Fixes #4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **Flatware** 
+# **Flatware**
 
 **Flatware** provides a tiny S3 buffer between you and Google Spreadsheets, protecting you from downtime, lag and the terrifying caprice of Mountain View. It's meant to be used with [Tabletop.js](https://github.com/jsoma/tabletop).
 
@@ -21,10 +21,14 @@ Alternatives can be found in Tabletop.js's `/caching` directory.
 
   heroku config:add AWS_ACCESS_KEY_ID=xxx AWS_SECRET_ACCESS_KEY=yyy AWS_BUCKET=zzz
 
+** Step Four Point Five**: If you're using the old version of Google Spreadsheets, set the following environment variable:
+
+  heroku config:add FLATWARE_USE_OLD_SHEETS=true
+
 **Step Five**: Visit your page and add a Google Spreadsheet. Maybe just use this one down here:
 
     https://docs.google.com/spreadsheet/pub?hl=en_US&hl=en_US&key=0AmYzu_s7QHsmdE5OcDE1SENpT1g2R2JEX2tnZ3ZIWHc&output=html
-    
+
 **Step Six**: Process the JSON to S3, using either `heroku run rake flatware:process` or clicking the **Sync all spreadsheets** button.
 
 **Step Seven**: Edit a Tabletop.js file to reflect your new cached set of data on S3. Try `/examples/proxy/index.html` and changing `proxy: 'https://s3.amazonaws.com/flatware-live'` to reflect your bucket

--- a/app.rb
+++ b/app.rb
@@ -2,74 +2,85 @@ DataMapper.setup(:default, ENV['DATABASE_URL'] || "sqlite3://#{Dir.pwd}/db/dev.s
 
 class Spreadsheet
   include DataMapper::Resource
-  
+
   property :id, Serial
   property :google_key, String, :unique => true, :required => true, :format => /\A[\w\-]*\z/
-  
+
   def base_json_path
     "/feeds/worksheets/#{google_key}/public/basic?alt=json-in-script&callback=Tabletop.singleton.loadSheets"
   end
-  
+
   def base_json_content
     @base_json_content ||= open(endpoint + base_json_path).read
   end
-  
+
   def sheet_paths
+    if ENV.key('FLATWARE_USE_OLD_SHEETS') && ENV['FLATWARE_USE_OLD_SHEETS'] == true
+      sq = "&sq="
+    else
+      sq = ""
+    end
+
     @sheet_paths ||= @sheet_ids.map{ |sheet_id|
-      "/feeds/list/#{google_key}/#{sheet_id}/public/values?alt=json-in-script&sq=&callback=Tabletop.singleton.loadSheet"
+      "/feeds/list/#{google_key}/#{sheet_id}/public/values?alt=json-in-script#{sq}&callback=Tabletop.singleton.loadSheet"
     }
   end
 
   def sheet_ids
     @sheet_ids ||= base_json_content.scan(/\/public\/basic\/([\w\-]*)/).flatten.uniq
   end
-  
+
   def storage
     @storage ||= Fog::Storage.new({:provider => 'AWS', :aws_access_key_id => ENV['AWS_ACCESS_KEY_ID'], :aws_secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']})
   end
-  
+
   def directory
     storage.directories.get(ENV['AWS_BUCKET']) || storage.directories.create(:key => ENV['AWS_BUCKET'], :public => true)
   end
-  
-  def write(path, options = {})    
+
+  def write(path, options = {})
     cached_filename = path.gsub(/[^\w\-]/,'')
     content = options[:content] || open(endpoint + path).read
-    # File.open("#{Sinatra::Application.settings.root}/tmp/#{cached_filename}", 'w') { |f| f.write(content) } 
+    # File.open("#{Sinatra::Application.settings.root}/tmp/#{cached_filename}", 'w') { |f| f.write(content) }
     upload(options[:filename] || cached_filename, content)
   end
-  
+
   def upload(filename, content)
     # Using an obsolete content_type because IE8 and before chokes on application/javascript and hey, Google does it.
     directory.files.create(:key => filename, :body => content, :public => true, :content_type => "text/javascript")
   end
-  
+
   def write_content
+    if ENV.key('FLATWARE_USE_OLD_SHEETS') && ENV['FLATWARE_USE_OLD_SHEETS'] == true
+      sq = "&sq="
+    else
+      sq = ""
+    end
     write(base_json_path, :content => base_json_content, :filename => google_key)
 
     sheet_ids.each do |sheet_id|
-      path = "/feeds/list/#{google_key}/#{sheet_id}/public/values?alt=json-in-script&sq=&callback=Tabletop.singleton.loadSheet"
+      path = "/feeds/list/#{google_key}/#{sheet_id}/public/values?alt=json-in-script#{sq}&callback=Tabletop.singleton.loadSheet"
       write(path, :filename => "#{google_key}-#{sheet_id}")
     end
   rescue OpenURI::HTTPError => e
     # Fail silently for the time being
   end
-  
+
   def endpoint
     "https://spreadsheets.google.com"
   end
-  
+
   class << self
-  
+
     def from_key(key)
       clean_key = key.gsub(/.*key=(.*?)\&.*/,'\1')
       Spreadsheet.new.tap do |sheet|
         sheet.google_key = clean_key
       end
     end
-    
+
   end
-  
+
 end
 
 DataMapper.finalize.auto_upgrade!
@@ -85,7 +96,7 @@ post '/' do
   else
     @error = "Could not add spreadsheet"
   end
-  
+
   erb :index
 end
 


### PR DESCRIPTION
See jsoma/tabletop#67. I made it use the new Sheets by default so it works out of the box for new users; if you'd rather I flip this behaviour so it uses the old format by default, please let me know. Ditto if you'd rather I change the environment variable name to something else.
